### PR TITLE
Silence handle extract variant exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@ build/
 *.iws
 .java-version
 
-# Documentation folder - contains drafts, AI-generated content, and other private content not intended for public repo
-docs/

--- a/app-sizer/src/main/kotlin/com/grab/sizer/parser/ProguardFileParser.kt
+++ b/app-sizer/src/main/kotlin/com/grab/sizer/parser/ProguardFileParser.kt
@@ -58,9 +58,9 @@ class DefaultProguardFileParser @Inject constructor(
                 readFromReader(InputStreamReader(it, Charsets.UTF_8))
             }
         } catch (e: IOException) {
-            logger.log(e)
+            logger.log("Parse mapping file failure", e)
         } catch (e: ParseException) {
-            logger.log(e)
+            logger.log("Parse mapping file failure", e)
         }
     }
 }

--- a/app-sizer/src/main/kotlin/com/grab/sizer/utils/Logger.kt
+++ b/app-sizer/src/main/kotlin/com/grab/sizer/utils/Logger.kt
@@ -32,17 +32,13 @@ const val DEFAULT_TAG = "AppSize"
 
 interface Logger {
     fun log(tag: String, message: String)
-    fun log(tag: String, e: Exception)
-    fun logDebug(tag: String, message: String)
+    fun log(tag: String, message: String, e: Exception)
 }
 
-fun Logger.logDebug(message: String) {
-    logDebug(DEFAULT_TAG, message)
-}
 fun Logger.log(message: String) {
     log(DEFAULT_TAG, message)
 }
 
-fun Logger.log(e: Exception) {
-    log(DEFAULT_TAG, e)
+fun Logger.log(message: String, e: Exception) {
+    log(DEFAULT_TAG, message, e)
 }

--- a/cli/src/main/kotlin/com/grab/sizer/utils/CliLogger.kt
+++ b/cli/src/main/kotlin/com/grab/sizer/utils/CliLogger.kt
@@ -32,12 +32,8 @@ class CliLogger : Logger {
         println("$tag : $message")
     }
 
-    override fun log(tag: String, e: Exception) {
-        println("$tag :")
-        e.printStackTrace()
-    }
-
-    override fun logDebug(tag: String, message: String) {
+    override fun log(tag: String, message: String, e: Exception) {
         println("$tag : $message")
+        e.printStackTrace()
     }
 }

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/AppSizerPlugin.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/AppSizerPlugin.kt
@@ -27,6 +27,7 @@
 
 package com.grab.plugin.sizer
 
+import com.grab.plugin.sizer.utils.DefaultPluginLogger
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -36,6 +37,7 @@ class AppSizerPlugin : Plugin<Project> {
     override fun apply(project: Project) =
         TaskManager(
             project,
-            project.extensions.create(PLUGIN_EXTENSION, AppSizePluginExtension::class.java)
+            project.extensions.create(PLUGIN_EXTENSION, AppSizePluginExtension::class.java),
+            DefaultPluginLogger(project)
         ).configTasks()
 }

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/ArchiveExtractor.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/ArchiveExtractor.kt
@@ -36,6 +36,15 @@ import org.gradle.api.Project
 import javax.inject.Inject
 
 interface ArchiveExtractor {
+    /**
+     * Extracts archive dependency from a project.
+     * 
+     * @param project The project to extract archive dependency from
+     * @return ArchiveDependency representing the project's binary output
+     * @throws UnsupportedOperationException if the project type is unsupported
+     * @throws IllegalStateException if variant extraction fails
+     */
+    @Throws(UnsupportedOperationException::class, IllegalStateException::class)
     fun extract(project: Project): ArchiveDependency
 }
 
@@ -43,6 +52,7 @@ interface ArchiveExtractor {
 internal class DefaultArchiveExtractor @Inject constructor(
     private val variantExtractor: VariantExtractor
 ) : ArchiveExtractor {
+    @Throws(UnsupportedOperationException::class, IllegalStateException::class)
     override fun extract(project: Project): ArchiveDependency {
         val matchVariant = variantExtractor.findMatchVariant(project)
         return when {
@@ -61,7 +71,7 @@ internal class DefaultArchiveExtractor @Inject constructor(
                pathToArtifact = matchVariant.binaryOutPut.path
            )
 
-            else -> throw IllegalArgumentException("The ${project.name} is not an Android/Kotlin/Java module")
+            else -> throw UnsupportedOperationException("Unsupported project type: ${project.name}")
         }
     }
 }

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/DependenciesComponent.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/DependenciesComponent.kt
@@ -27,6 +27,7 @@
 
 package com.grab.plugin.sizer.dependencies
 
+import com.grab.plugin.sizer.utils.DefaultPluginLogger
 import com.grab.plugin.sizer.utils.PluginLogger
 import com.grab.sizer.utils.Logger
 import dagger.Binds
@@ -49,8 +50,6 @@ internal interface DependenciesComponent {
     fun dependencyExtractor(): DependencyExtractor
     fun configurationExtractor(): ConfigurationExtractor
     fun variantExtractor(): VariantExtractor
-
-    fun logger(): Logger
 
     @Component.Factory
     interface Factory {
@@ -79,5 +78,5 @@ internal interface DependenciesModule {
     fun bindVariantExtractor(extractor: DefaultVariantExtractor): VariantExtractor
 
     @Binds
-    fun bindLogger(logger: PluginLogger): Logger
+    fun bindLogger(logger: DefaultPluginLogger): PluginLogger
 }

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/tasks/AppSizeAnalysisTask.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/tasks/AppSizeAnalysisTask.kt
@@ -37,8 +37,8 @@ import com.grab.plugin.sizer.dependencies.ArchiveDependencyStore
 import com.grab.plugin.sizer.dependencies.VariantInput
 import com.grab.plugin.sizer.dependencies.toVariantInput
 import com.grab.plugin.sizer.params
+import com.grab.plugin.sizer.utils.DefaultPluginLogger
 import com.grab.plugin.sizer.utils.PluginInputProvider
-import com.grab.plugin.sizer.utils.PluginLogger
 import com.grab.plugin.sizer.utils.PluginOutputProvider
 import com.grab.sizer.AnalyticsOption
 import com.grab.sizer.AppSizer
@@ -123,7 +123,7 @@ internal abstract class AppSizeAnalysisTask : DefaultTask() {
                 inputProvider = createInputProvider(archiveDependencyStore, apkDirectory),
                 outputProvider = createOutputProvider(projectInfo),
                 libName = libName.orNull,
-                logger = PluginLogger(project),
+                logger = DefaultPluginLogger(project),
             ).process(option.get())
         }
 
@@ -181,7 +181,7 @@ internal abstract class AppSizeAnalysisTask : DefaultTask() {
                     this.outputDirectory.set(project.layout.buildDirectory.dir("sizer/reports/${variant.name}"))
                 }
 
-                if(pluginExtension.input.teamMappingFile.isPresent){
+                if (pluginExtension.input.teamMappingFile.isPresent) {
                     this.teamMappingFile.set(pluginExtension.input.teamMappingFile)
                 }
 

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/utils/Logger.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/utils/Logger.kt
@@ -28,15 +28,48 @@
 package com.grab.plugin.sizer.utils
 
 import com.grab.plugin.sizer.dependencies.DependenciesScope
+import com.grab.sizer.utils.DEFAULT_TAG
 import com.grab.sizer.utils.Logger
 import org.gradle.api.Project
 import org.gradle.api.logging.LogLevel
 import javax.inject.Inject
 
-@DependenciesScope
-class PluginLogger @Inject constructor(private val project: Project) : Logger {
-    override fun log(tag: String, message: String) = project.logger.log(LogLevel.QUIET, "$tag: $message")
 
-    override fun logDebug(tag: String, message: String) = project.logger.log(LogLevel.DEBUG, "$tag: $message")
-    override fun log(tag: String, e: Exception) = project.logger.log(LogLevel.DEBUG, tag, e)
+interface PluginLogger : Logger {
+    fun warn(tag: String, message: String)
+    fun warn(tag: String, message: String, e: Exception)
+
+    fun debug(tag: String, message: String)
+    fun debug(tag: String, message: String, e: Exception)
+}
+
+fun PluginLogger.warn(message: String) {
+    warn(DEFAULT_TAG, message)
+}
+
+fun PluginLogger.warn(message: String, e: Exception) {
+    warn(DEFAULT_TAG, message, e)
+}
+
+fun PluginLogger.debug(message: String) {
+    debug(DEFAULT_TAG, message)
+}
+
+fun PluginLogger.debug(message: String, e: Exception) {
+    debug(DEFAULT_TAG, message, e)
+}
+
+
+@DependenciesScope
+class DefaultPluginLogger @Inject constructor(private val project: Project) : PluginLogger {
+    override fun log(tag: String, message: String) = project.logger.log(LogLevel.QUIET, "$tag: $message")
+    override fun log(tag: String, message: String, e: Exception) =
+        project.logger.log(LogLevel.DEBUG, "$tag: $message", e)
+
+    override fun warn(tag: String, message: String) = project.logger.warn("$tag: $message")
+
+    override fun warn(tag: String, message: String, e: Exception) = project.logger.warn("$tag: $message", e)
+
+    override fun debug(tag: String, message: String) = project.logger.debug("$tag: $message")
+    override fun debug(tag: String, message: String, e: Exception) = project.logger.debug("$tag: $message", e)
 }

--- a/sizer-gradle-plugin/src/test/kotlin/com/grab/plugin/sizer/dependencies/DefaultVariantExtractorTest.kt
+++ b/sizer-gradle-plugin/src/test/kotlin/com/grab/plugin/sizer/dependencies/DefaultVariantExtractorTest.kt
@@ -81,7 +81,7 @@ class DefaultVariantExtractorTest {
         val project = ProjectBuilder.builder().withParent(rootProject).build()
         project.doEvaluate()
 
-        assertThrows<IllegalArgumentException>("${project.name} is not supported") {
+        assertThrows<UnsupportedOperationException>("Project type not supported: ${project.name}") {
             extractor.findMatchVariant(project)
         }
     }

--- a/sizer-gradle-plugin/src/test/kotlin/com/grab/plugin/sizer/fake/MockLogger.kt
+++ b/sizer-gradle-plugin/src/test/kotlin/com/grab/plugin/sizer/fake/MockLogger.kt
@@ -27,20 +27,32 @@
 
 package com.grab.plugin.sizer.fake
 
-import com.grab.sizer.utils.Logger
+import com.grab.plugin.sizer.utils.PluginLogger
 
-class MockLogger : Logger {
+class MockLogger : PluginLogger {
     val loggedMessages = mutableListOf<String>()
 
     override fun log(tag: String, message: String) {
         loggedMessages.add("$tag: $message")
     }
 
-    override fun log(tag: String, e: Exception) {
-        loggedMessages.add("$tag: ${e.message}")
+    override fun log(tag: String, message: String, e: Exception) {
+        loggedMessages.add("$tag: $message ${e.message}")
     }
 
-    override fun logDebug(tag: String, message: String) {
+    override fun warn(tag: String, message: String) {
+        loggedMessages.add("$tag: $message")
+    }
+
+    override fun warn(tag: String, message: String, e: Exception) {
+        loggedMessages.add("$tag: $message ${e.message}")
+    }
+
+    override fun debug(tag: String, message: String) {
         loggedMessages.add("DEBUG - $tag: $message")
+    }
+
+    override fun debug(tag: String, message: String, e: Exception) {
+        loggedMessages.add("DEBUG - $tag: $message ${e.message}")
     }
 }


### PR DESCRIPTION
## Proposed Changes
Prevent build crashes when the app-sizer plugin encounters projects with incompatible or missing build variant configurations.
