### PR TITLE
Prepare build for Gradle 9: Dagger, Dokka 2 and publishing script update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,5 +38,6 @@ plugins {
     alias(libs.plugins.johnrengelman.shadow) apply false
     alias(libs.plugins.gradle.plugin.publish) apply false
     alias(libs.plugins.dokka.gradle.plugin) apply false
+    alias(libs.plugins.dokka.javadoc) apply false
 }
 apply from: "gradle/publish-root-config.gradle"

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,6 @@ org.gradle.parallel=true
 org.gradle.caching=true
 # Kotlin code style
 kotlin.code.style=official
+# Dokka 2.x: enable the V2 Gradle plugin mode
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ gradle-plugin-publish = "0.14.0"
 android-gradle-plugin = "8.5.1"
 kotlin = "1.9.22"
 kotlin-dsl = "4.3.1"
-dagger = "2.47"
+dagger = "2.60.1"
 dexlib2 = "2.5.2"
 clikt = "4.4.0"
 bundletool = "1.14.1"
@@ -15,7 +15,7 @@ gson = "2.10.1"
 influxdbClient = "2.24"
 shadow-jar = "7.0.0"
 nexus = "2.0.0"
-dokka = "1.9.20"
+dokka = "2.1.0"
 
 # Tests
 junit = "4.13.2"
@@ -49,4 +49,5 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 johnrengelman-shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow-jar" }
 dokka-gradle-plugin = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
 

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -15,7 +15,7 @@
  */
 apply plugin: "maven-publish"
 apply plugin: "signing"
-apply plugin: "org.jetbrains.dokka"
+apply plugin: "org.jetbrains.dokka-javadoc"
 
 task sourcesJar(type: Jar) {
     group = "publishing"
@@ -24,10 +24,13 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.kotlin.srcDirs
 }
 
-task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
+def dokkaJavadocTask = tasks.named("dokkaGeneratePublicationJavadoc")
+
+task javadocJar(type: Jar) {
+    dependsOn dokkaJavadocTask
     group = "publishing"
     archiveClassifier.set("javadoc")
-    from dokkaJavadoc.outputDirectory
+    from dokkaJavadocTask.map { it.outputDirectory }
 }
 
 artifacts {
@@ -117,9 +120,9 @@ afterEvaluate {
             }
 
             release(MavenPublication) { publication ->
-                groupId project.findProperty("groupId")
-                artifactId project.name
-                version project.findProperty("versionName")
+                groupId = project.findProperty("groupId")
+                artifactId = project.name
+                version = project.findProperty("versionName")
 
                 from components.java
 

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/configuration/MetricExtension.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/configuration/MetricExtension.kt
@@ -33,7 +33,6 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.gradle.kotlin.dsl.property
 import javax.inject.Inject
 
 open class MetricExtension @Inject constructor(project: Project) {
@@ -65,19 +64,19 @@ open class MetricExtension @Inject constructor(project: Project) {
 }
 
 open class RetentionPolicyExtension @Inject constructor(objects: ObjectFactory) {
-    val name: Property<String> = objects.property<String>()
-    val duration: Property<String> = objects.property<String>()
-    val shardDuration: Property<String> = objects.property<String>()
-    val replicationFactor: Property<Int> = objects.property<Int>()
-    val setAsDefault: Property<Boolean> = objects.property<Boolean>().convention(false)
+    val name: Property<String> = objects.property(String::class.java)
+    val duration: Property<String> = objects.property(String::class.java)
+    val shardDuration: Property<String> = objects.property(String::class.java)
+    val replicationFactor: Property<Int> = objects.property(Int::class.java)
+    val setAsDefault: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 }
 
 open class InfluxDBExtension @Inject constructor(private val objects: ObjectFactory) {
-    val dbName: Property<String> = objects.property<String>()
-    val url: Property<String> = objects.property<String>()
-    val username: Property<String> = objects.property<String>()
-    val password: Property<String> = objects.property<String>()
-    val reportTableName: Property<String> = objects.property<String>()
+    val dbName: Property<String> = objects.property(String::class.java)
+    val url: Property<String> = objects.property(String::class.java)
+    val username: Property<String> = objects.property(String::class.java)
+    val password: Property<String> = objects.property(String::class.java)
+    val reportTableName: Property<String> = objects.property(String::class.java)
     val retentionPolicy: RetentionPolicyExtension = objects.newInstance(RetentionPolicyExtension::class.java)
 
     fun retentionPolicy(closure: Closure<*>) {


### PR DESCRIPTION
…ates

Groundwork for the Gradle 9 / AGP 9 migration; everything here builds and passes tests on the current Gradle 8.8 / AGP 8.5.1 toolchain.

- Bump Dagger 2.47 -> 2.60.1
- Migrate Dokka 1.9.20 -> 2.1.0 (V2 plugin mode): javadoc jars are now produced by the org.jetbrains.dokka-javadoc plugin's dokkaGeneratePublicationJavadoc task
- Replace Groovy space-assignment syntax in publishing.gradle with explicit assignments (removed in Gradle 9)
- Replace the org.gradle.kotlin.dsl reified property() helpers in MetricExtension with the plain ObjectFactory API

## Proposed Changes

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed