### PR TITLE
CI: use JDK 17 in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
 
       - name: Get version
         id: get_version


### PR DESCRIPTION
Gradle 9 requires Java 17 to run; the release job still set up JDK 11. The build and test jobs already use 17.

## Proposed Changes

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed