### PR TITLE
Prepare release 0.2.0-alpha01

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -27,5 +27,5 @@
 
 ext {
     groupId = "com.grab.sizer"
-    versionName = project.hasProperty("versionName") ? versionName : "0.1.0-alpha03"
+    versionName = project.hasProperty("versionName") ? versionName : "0.2.0-alpha01"
 }

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -5,7 +5,7 @@ App Sizer provide a gradle plugin as the option to seamlessly integrates with yo
 
 | App Sizer Plugin | Android Gradle Plugin | Gradle | JDK |
 |------------------|-----------------------|--------|-----|
-| Latest | 9.0+ | 9.1+ | 17+ |
+| 0.2.0-alpha01 and above | 9.0+ | 9.1+ | 17+ |
 | 0.1.0-alpha03 and below | 8.x | 8.x | 17+ |
 
 ## Getting Started
@@ -25,13 +25,13 @@ pluginManagement {
 2. Add the plugin to your project classpath (root's build.gradle):
 ```groovy
 plugins {
-    id "com.grab.sizer" version "0.1.0-alpha02" apply false
+    id "com.grab.sizer" version "0.2.0-alpha01" apply false
 }
 ```
 3. Apply and configure the plugin to your app module's build.gradle:
 ```groovy
 plugins {
-    id "com.grab.sizer" version "0.1.0-alpha02"
+    id "com.grab.sizer" version "0.2.0-alpha01"
 }
 
 appSizer {
@@ -47,7 +47,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.grab.sizer:sizer-gradle-plugin:0.1.0-alpha02"
+        classpath "com.grab.sizer:sizer-gradle-plugin:0.2.0-alpha01"
     }
 }
 ```

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -126,8 +126,12 @@ afterEvaluate {
 
                 from components.java
 
-                artifact sourcesJar
-                artifact javadocJar
+                // plugin-publish already adds sources/javadoc jars to the java component;
+                // attaching them again would create duplicate artifacts in the publication
+                if (!project.plugins.hasPlugin("com.gradle.plugin-publish")) {
+                    artifact sourcesJar
+                    artifact javadocJar
+                }
 
                 configurePom(publication)
             }


### PR DESCRIPTION
- Bump the default version to 0.2.0-alpha01; this release requires AGP 9 / Gradle 9.1 (see the compatibility table in docs/plugin.md)
- Update the plugin version in the documentation examples
- Fix duplicate javadoc/sources artifacts in the Maven publication: plugin-publish 2.x already adds them to the java component, so the manual artifacts are only attached when plugin-publish is not applied

## Proposed Changes

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed