### PR TITLE
Remove Dagger from sizer-gradle-plugin

### DIFF
--- a/sizer-gradle-plugin/build.gradle
+++ b/sizer-gradle-plugin/build.gradle
@@ -45,9 +45,7 @@ dependencies {
     compileOnly libs.android.gradle.api
 
     implementation project(':app-sizer')
-    implementation libs.google.dagger
     implementation libs.gson
-    kapt libs.dagger.compiler
 
     testImplementation libs.junit
     testImplementation gradleTestKit()

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/TaskManager.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/TaskManager.kt
@@ -124,7 +124,7 @@ internal class TaskManager(
         buildTypeMatchingFallbacks: List<String>,
         depTask: TaskProvider<out Task>
     ) {
-        val dependenciesComponent = DaggerDependenciesComponent.factory().create(
+        val dependenciesComponent = DependenciesComponent(
             project = project,
             variantInput = variantInput,
             flavorMatchingFallbacks = flavorMatchingFallbacks,
@@ -143,8 +143,8 @@ internal class TaskManager(
     ) {
         if (markAsChecked.contains(project.path)) return
         markAsChecked.add(project.path)
-        handleSubProject(project, depTask, dependenciesComponent.variantExtractor())
-        dependenciesComponent.configurationExtractor()
+        handleSubProject(project, depTask, dependenciesComponent.variantExtractor)
+        dependenciesComponent.configurationExtractor
             .runtimeConfigurations(project)
             .flatMap { configuration ->
                 configuration.dependencies.withType(ProjectDependency::class.java)

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/ArchiveExtractor.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/ArchiveExtractor.kt
@@ -33,7 +33,6 @@ import com.grab.plugin.sizer.utils.isJava
 import com.grab.plugin.sizer.utils.isKotlinJvm
 import com.grab.plugin.sizer.utils.isKotlinMultiplatform
 import org.gradle.api.Project
-import javax.inject.Inject
 
 interface ArchiveExtractor {
     /**
@@ -48,8 +47,7 @@ interface ArchiveExtractor {
     fun extract(project: Project): ArchiveDependency
 }
 
-@DependenciesScope
-internal class DefaultArchiveExtractor @Inject constructor(
+internal class DefaultArchiveExtractor(
     private val variantExtractor: VariantExtractor
 ) : ArchiveExtractor {
     @Throws(UnsupportedOperationException::class, IllegalStateException::class)

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/DefaultConfigurationExtractor.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/DefaultConfigurationExtractor.kt
@@ -32,14 +32,12 @@ import com.grab.plugin.sizer.utils.debug
 import com.grab.plugin.sizer.utils.warn
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
-import javax.inject.Inject
 
 interface ConfigurationExtractor {
     fun runtimeConfigurations(project: Project): Sequence<Configuration>
 }
 
-@DependenciesScope
-internal class DefaultConfigurationExtractor @Inject constructor(
+internal class DefaultConfigurationExtractor(
     private val variantExtractor: VariantExtractor,
     private val logger: PluginLogger
 ) : ConfigurationExtractor {

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/DependenciesComponent.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/DependenciesComponent.kt
@@ -29,54 +29,37 @@ package com.grab.plugin.sizer.dependencies
 
 import com.grab.plugin.sizer.utils.DefaultPluginLogger
 import com.grab.plugin.sizer.utils.PluginLogger
-import com.grab.sizer.utils.Logger
-import dagger.Binds
-import dagger.BindsInstance
-import dagger.Component
-import dagger.Module
 import org.gradle.api.Project
-import javax.inject.Named
-import javax.inject.Scope
 
-@Scope
-@Retention(AnnotationRetention.RUNTIME)
-internal annotation class DependenciesScope
+/**
+ * Hand-wired object graph for the dependency extraction of one variant, replacing the
+ * previous Dagger component. Dagger was removed from the plugin because the buildscript
+ * classpath offers no dependency isolation, so another plugin's Dagger version can clash
+ * with the generated code at runtime.
+ */
+internal class DependenciesComponent(
+    project: Project,
+    variantInput: VariantInput,
+    flavorMatchingFallbacks: List<String>,
+    buildTypeMatchingFallbacks: List<String>,
+    enableMatchDebugVariant: Boolean,
+) {
+    private val logger: PluginLogger = DefaultPluginLogger(project)
 
-@Component(
-    modules = [DependenciesModule::class]
-)
-@DependenciesScope
-internal interface DependenciesComponent {
-    fun dependencyExtractor(): DependencyExtractor
-    fun configurationExtractor(): ConfigurationExtractor
-    fun variantExtractor(): VariantExtractor
+    val variantExtractor: VariantExtractor = DefaultVariantExtractor(
+        variantInput = variantInput,
+        flavorMatchingFallbacks = flavorMatchingFallbacks,
+        buildTypeMatchingFallbacks = buildTypeMatchingFallbacks,
+        enableMatchDebugVariant = enableMatchDebugVariant,
+    )
 
-    @Component.Factory
-    interface Factory {
-        fun create(
-            @BindsInstance project: Project,
-            @BindsInstance variantInput: VariantInput,
-            @BindsInstance @Named(BUILD_FLAVOR) flavorMatchingFallbacks: List<String>,
-            @BindsInstance @Named(BUILD_TYPE) buildTypeMatchingFallbacks: List<String>,
-            @BindsInstance @Named(ENABLE_MATCH_DEBUG_VARIANT) enableMatchDebugVariant: Boolean
-        ): DependenciesComponent
-    }
-}
+    val configurationExtractor: ConfigurationExtractor =
+        DefaultConfigurationExtractor(variantExtractor, logger)
 
-@Module
-internal interface DependenciesModule {
-    @Binds
-    fun bindArchiveExtractor(extractor: DefaultArchiveExtractor): ArchiveExtractor
-
-    @Binds
-    fun bindConfigurationExtractor(extractor: DefaultConfigurationExtractor): ConfigurationExtractor
-
-    @Binds
-    fun bindDependencyExtractor(extractor: DefaultDependencyExtractor): DependencyExtractor
-
-    @Binds
-    fun bindVariantExtractor(extractor: DefaultVariantExtractor): VariantExtractor
-
-    @Binds
-    fun bindLogger(logger: DefaultPluginLogger): PluginLogger
+    val dependencyExtractor: DependencyExtractor = DefaultDependencyExtractor(
+        appProject = project,
+        configurationExtractor = configurationExtractor,
+        archiveExtractor = DefaultArchiveExtractor(variantExtractor),
+        logger = logger,
+    )
 }

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/DependencyExtractor.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/DependencyExtractor.kt
@@ -36,7 +36,6 @@ import org.gradle.api.artifacts.ResolveException
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedDependency
 import java.util.*
-import javax.inject.Inject
 
 typealias ArchiveDependencyStore = HashSet<ArchiveDependency>
 
@@ -47,8 +46,7 @@ interface DependencyExtractor {
 
 private const val INTERNAL_DEP_VERSION = "unspecified"
 
-@DependenciesScope
-class DefaultDependencyExtractor @Inject constructor(
+class DefaultDependencyExtractor(
     private val appProject: Project,
     private val configurationExtractor: ConfigurationExtractor,
     private val archiveExtractor: ArchiveExtractor,

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/VariantExtractor.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/dependencies/VariantExtractor.kt
@@ -36,13 +36,8 @@ import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.jvm.tasks.Jar
 import java.io.File
 import java.io.Serializable
-import javax.inject.Inject
-import javax.inject.Named
 
 
-internal const val BUILD_TYPE = "BUILD_TYPE"
-internal const val BUILD_FLAVOR = "BUILD_FLAVOR"
-internal const val ENABLE_MATCH_DEBUG_VARIANT = "ENABLE_MATCH_DEBUG_VARIANT"
 internal const val BUILD_TYPE_DEBUG = "debug"
 internal const val KMP_JAR_TASK = "jvmJar"
 private const val RUNTIME_CLASSPATH_SUFFIX = "RuntimeClasspath"
@@ -141,14 +136,10 @@ private fun List<String>.toCamelCase(): String =
  * @property buildTypeMatchingFallbacks references list of build types to be used as fallbacks.
  * @property enableMatchDebugVariant specifies whether to match debug variant.
  */
-@DependenciesScope
-internal class DefaultVariantExtractor @Inject constructor(
+internal class DefaultVariantExtractor(
     private val variantInput: VariantInput,
-    @Named(BUILD_FLAVOR)
     private val flavorMatchingFallbacks: List<String>,
-    @Named(BUILD_TYPE)
     private val buildTypeMatchingFallbacks: List<String>,
-    @Named(ENABLE_MATCH_DEBUG_VARIANT)
     private val enableMatchDebugVariant: Boolean,
 ) : VariantExtractor {
 

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/tasks/GenerateApkTask.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/tasks/GenerateApkTask.kt
@@ -57,17 +57,12 @@ private const val DEFAULT_DEVICE_SPEC = """
 
 internal const val DEFAULT_DEVICE_NAME = "default_device"
 
-/**
- * Grants a task access to the [ExecOperations] service. Direct `@Inject` on the task breaks
- * the Dagger annotation processor (abstract members with `@Inject` are rejected), so the
- * service is obtained through this injectable holder via [org.gradle.api.model.ObjectFactory].
- */
-internal open class ExecOperationsHolder @Inject constructor(val execOperations: ExecOperations)
-
 @CacheableTask
 internal abstract class GenerateApkTask : DefaultTask() {
 
-    private val execOperations = project.objects.newInstance(ExecOperationsHolder::class.java).execOperations
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
     private val buildDirectory = project.layout.buildDirectory
 
     @get:InputFile

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/tasks/GenerateArchivesListTask.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/tasks/GenerateArchivesListTask.kt
@@ -101,11 +101,11 @@ internal abstract class GenerateArchivesListTask : DefaultTask() {
              * accommodating potential build type incompatibilities.
              */
             val modules = createDependenciesComponent(true)
-                .dependencyExtractor()
+                .dependencyExtractor
                 .extract()
                 .filter { it !is ExternalDependency }
             val libraries = createDependenciesComponent(false)
-                .dependencyExtractor()
+                .dependencyExtractor
                 .extract()
                 .filterIsInstance<ExternalDependency>()
 
@@ -117,7 +117,7 @@ internal abstract class GenerateArchivesListTask : DefaultTask() {
         } else {
             createDependenciesComponent(false).run {
                 ArchiveDependencyManager().writeToJsonFile(
-                    dependencyExtractor().extract(),
+                    dependencyExtractor.extract(),
                     archiveDepFile.get().asFile
                 )
             }
@@ -126,7 +126,7 @@ internal abstract class GenerateArchivesListTask : DefaultTask() {
     }
 
     private fun createDependenciesComponent(enableMatchDebugVariant: Boolean): DependenciesComponent =
-        DaggerDependenciesComponent.factory().create(
+        DependenciesComponent(
             project,
             variantInput.get(),
             flavorMatchingFallbacks.get(),

--- a/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/utils/Logger.kt
+++ b/sizer-gradle-plugin/src/main/kotlin/com/grab/plugin/sizer/utils/Logger.kt
@@ -27,12 +27,10 @@
 
 package com.grab.plugin.sizer.utils
 
-import com.grab.plugin.sizer.dependencies.DependenciesScope
 import com.grab.sizer.utils.DEFAULT_TAG
 import com.grab.sizer.utils.Logger
 import org.gradle.api.Project
 import org.gradle.api.logging.LogLevel
-import javax.inject.Inject
 
 
 interface PluginLogger : Logger {
@@ -60,8 +58,7 @@ fun PluginLogger.debug(message: String, e: Exception) {
 }
 
 
-@DependenciesScope
-class DefaultPluginLogger @Inject constructor(private val project: Project) : PluginLogger {
+class DefaultPluginLogger(private val project: Project) : PluginLogger {
     override fun log(tag: String, message: String) = project.logger.log(LogLevel.QUIET, "$tag: $message")
     override fun log(tag: String, message: String, e: Exception) =
         project.logger.log(LogLevel.DEBUG, "$tag: $message", e)


### PR DESCRIPTION
Completes the Dagger removal for code that runs on the Gradle buildscript classpath (see the app-sizer core removal for the rationale: another plugin's Dagger version can shadow ours at runtime since Gradle offers no dependency isolation between plugins).

- Replace the Dagger DependenciesComponent with a hand-wired class of the same name; extractors are exposed as properties instead of methods
- Strip @Inject/@Named/@DependenciesScope from the extractor and logger classes; Gradle-managed types (extensions, tasks) keep their javax.inject annotations, which Gradle itself requires
- GenerateApkTask: drop the ExecOperationsHolder workaround and inject ExecOperations directly via an abstract @get:Inject property; the holder only existed because Dagger's annotation processor rejected that pattern
- Drop dagger/dagger-compiler (kapt) from the plugin build

Co-ordinates with the core removal MR; a follow-up removes kapt from build-logic and the version catalog.

## Proposed Changes

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed